### PR TITLE
Deleted unneded extension.

### DIFF
--- a/3_frames2movie.sh
+++ b/3_frames2movie.sh
@@ -10,7 +10,7 @@ ffmpeg -framerate 25 -i $1/%4d.jpg -c:v libx264 -r 30 -pix_fmt yuv420p tmp.mp4
 ffmpeg -i $2 original.mp3
 ffmpeg -i original.mp3 music.wav
 
-secs=$(ffprobe -i $2.mp4 -show_entries format=duration -v quiet -of csv="p=0")
+secs=$(ffprobe -i $2 -show_entries format=duration -v quiet -of csv="p=0")
 ffmpeg -i music.wav -ss 0 -t $secs musicshort.wav
 ffmpeg -i musicshort.wav -i tmp.mp4 -strict -2 $1.mp4
 rm tmp.mp4


### PR DESCRIPTION
Extension of the media file is supposed to be included into the second argument. No need to add it when ffprobing original media.