### PR TITLE
missing comma

### DIFF
--- a/2_dreaming_time.py
+++ b/2_dreaming_time.py
@@ -298,7 +298,7 @@ if __name__ == "__main__":
         '-l','--layers',
         nargs="+", 
         type=str, 
-        required=False
+        required=False,
         help='Array of Layers to loop through. Default: [customloop] \
         - or choose ie [inception_4c/output] for that single layer')
     


### PR DESCRIPTION
there was a comma missing, leading to 

```
  File "2_dreaming_time.py", line 302
    help='Array of Layers to loop through. Default: [customloop] \
       ^
SyntaxError: invalid syntax
```