### PR TITLE
bug fix: You can't use set_mode in Caffe CPU mode

### DIFF
--- a/2_dreaming_time.py
+++ b/2_dreaming_time.py
@@ -158,14 +158,11 @@ def main(input, output, disp, gpu, model_path, model_name, preview, octaves, oct
                            
     # should be picked up by caffe by default, but just in case
     # standard caffe:
-    if gpu:
+    if gpu != '0':
         caffe.set_mode_gpu()
         caffe.set_device(int(args.gpu))
         print("GPU mode [device id: %s]" % args.gpu)
         print("using GPU, but you'd still better make a cup of coffee")
-    else:
-        caffe.set_mode_cpu()
-        print("CPU mode")
     
     if disp:
         from IPython.display import clear_output, Image, display


### PR DESCRIPTION
Hi, I've tried yours code, and according to this bug: https://github.com/BVLC/caffe/issues/1799 ,
you can't set_mode in CPU mode at all. Caffe fails at this point.
Also, seems like you passing string to gpu variable, but there is no chance for it to be false except empty string, which is't obvious. Now project runs perfect on MacBook inside docker with ubuntu.

The point is that CPU mode is set by default, while you setting it gpu to '0', so you don't need to pass this parameter at all, if your machine can't handle GPU mode. For me it's much clearer solution, but I might be wrong