### PR TITLE
Removed unneded -r parameter for FFMPEG

### DIFF
--- a/1_movie2frames.sh
+++ b/1_movie2frames.sh
@@ -1,13 +1,16 @@
 #!/bin/bash
 if [ $# -ne 3 ]; then
     echo "please provide the moviename and directory where to store the frames"
-    echo "./1_movie2frames [ffmpeg|avconv] [movie.mp4] [directory]"
+    echo "usage:"
+    echo "./1_movie2frames [ffmpeg|avconv] [movie.ext] [directory]"
+    echo "\n example:
+    echo "      ./1_movie2frames ffmpeg /home/user/fearloath.mp4 /home/user/framesloath/"
     exit 1
 fi
 
 mkdir -p $3
 if [ "avconf" == "$1" ]; then
-    avconv -i $2 -vsync 1 -r 25 -an -y -qscale 0 $3/%04d.jpg
+    avconv -i $2 -vsync 1 -an -y -qscale 0 $3/%04d.jpg
 else
-    ffmpeg -i $2 -r 25.0 $3/%4d.jpg
+    ffmpeg -i $2 $3/%4d.jpg
 fi

--- a/1_movie2frames.sh
+++ b/1_movie2frames.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 if [ $# -ne 3 ]; then
     echo "please provide the moviename and directory where to store the frames"
-    echo "./1_movie2frames [ffmpeg|avconv] [movie.mp4] [directory]"
+    echo "./1_movie2frames [ffmpeg|avconv|mplayer] [movie.mp4] [directory]"
     exit 1
 fi
 
@@ -10,7 +10,7 @@ rm -R "$3/*"
 if [ "avconv" == "$1" ]; then
     AVCONV=$(which avconv)
     FPS=$($AVCONV -i filename 2>&1 | sed -n "s/.*, \(.*\) fp.*/\1/p") # this line is not tested cuz i don't have avconv :(
-    $AVCONV -i "$2" -vsync 1 -an -y -qscale 0 "$3/%08d.jpg"
+    $AVCONV -i "$2" -vsync 1 -r ${FPS} -an -y -qscale 0 "$3/%08d.jpg"
 elif [ "mplayer" == "$1" ]; then
     MPLAYER=$(which mplayer)
     # mplayer automatically converts video to images at one image per frame (so no need for the FPS), so the following line is not necessary - but for the record, this is what you would use:

--- a/1_movie2frames.sh
+++ b/1_movie2frames.sh
@@ -1,26 +1,7 @@
 #!/bin/bash
 if [ $# -ne 3 ]; then
     echo "please provide the moviename and directory where to store the frames"
-<<<<<<< HEAD
-<<<<<<< HEAD
-    echo "usage:"
-    echo "./1_movie2frames [ffmpeg|avconv] [movie.ext] [directory]"
-    echo "\n example:
-    echo "      ./1_movie2frames ffmpeg /home/user/fearloath.mp4 /home/user/framesloath/"
-=======
     echo "./1_movie2frames [ffmpeg|avconv] [movie.mp4] [directory]"
->>>>>>> parent of 303a3a3... Removed framerate to use original from video.
-    exit 1
-fi
-
-mkdir -p $3
-if [ "avconf" == "$1" ]; then
-    avconv -i $2 -vsync 1 -r 25 -an -y -qscale 0 $3/%04d.jpg
-else
-<<<<<<< HEAD
-    ffmpeg -i $2 $3/%4d.jpg
-=======
-    echo "./1_movie2frames [ffmpeg|avconv|mplayer] [movie.mp4] [directory]"
     exit 1
 fi
 
@@ -29,7 +10,7 @@ rm -R "$3/*"
 if [ "avconv" == "$1" ]; then
     AVCONV=$(which avconv)
     FPS=$($AVCONV -i filename 2>&1 | sed -n "s/.*, \(.*\) fp.*/\1/p") # this line is not tested cuz i don't have avconv :(
-    $AVCONV -i "$2" -vsync 1 -r ${FPS} -an -y -qscale 0 "$3/%08d.jpg"
+    $AVCONV -i "$2" -vsync 1 -an -y -qscale 0 "$3/%08d.jpg"
 elif [ "mplayer" == "$1" ]; then
     MPLAYER=$(which mplayer)
     # mplayer automatically converts video to images at one image per frame (so no need for the FPS), so the following line is not necessary - but for the record, this is what you would use:
@@ -37,11 +18,8 @@ elif [ "mplayer" == "$1" ]; then
     $MPLAYER -vo "jpeg:outdir=$3" -ao null "$2"
 else
     FFMPEG=$(which ffmpeg)
-    FFPROBE=$(which ffprobe)
-    FPS=$($FFPROBE -show_streams -select_streams v -i "$2"  2>/dev/null | grep "r_frame_rate" | cut -d'=' -f2)
-    $FFMPEG -i "$2" -r ${FPS} -f image2 "$3/%08d.jpg"
->>>>>>> 426b081b064d3748dae053f0efd1892fa7b7100c
-=======
-    ffmpeg -i $2 -r 25.0 $3/%4d.jpg
->>>>>>> parent of 303a3a3... Removed framerate to use original from video.
+    #Same happens with FFMPEG as MPLAYER, fps is not needed for video to frame convertion.
+    #FFPROBE=$(which ffprobe)
+    #FPS=$($FFPROBE -show_streams -select_streams v -i "$2"  2>/dev/null | grep "r_frame_rate" | cut -d'=' -f2)
+    $FFMPEG -i "$2" -f image2 "$3/%08d.jpg"
 fi

--- a/3_frames2movie.sh
+++ b/3_frames2movie.sh
@@ -1,39 +1,31 @@
 #!/bin/bash
 if [ $# -ne 2 ]; then
     echo "please provide the directory of the processed frames"
-    echo "usage:"
     echo "./3_frames2movie.sh [frames_directory] [original_video_with_sound]"
-    echo "\n example:"
-    echo "      ./3_frames2movie.sh /home/user/framesloath/ /home/user/fearloath.mp4"
     exit 1
 fi
 
-<<<<<<< HEAD
-# FFMPEG NEEDED -- TODO: Develop avconv alternative for this, or delete the avconv option in the first bash script.
-
-# Detect framerate of the original video
-frate=$(ffprobe -v error -select_streams v:0 -show_entries stream=avg_frame_rate -of default=noprint_wrappers=1:nokey=1 $2)
-ffmpeg -framerate $frate -i $1/%4d.jpg -c:v libx264 -r 30 -pix_fmt yuv420p tmp.mp4 # Use original framerate
-=======
 FFMPEG=$(which ffmpeg)
 FFPROBE=$(which ffprobe)
->>>>>>> 426b081b064d3748dae053f0efd1892fa7b7100c
 
 ${FFMPEG} -framerate 25 -i "$1/%08d.jpg" -c:v libx264 -vf "fps=25,format=yuv420p" -tune fastdecode -tune zerolatency -profile:v baseline /tmp/tmp.mp4 -y
 
-<<<<<<< HEAD
-# Test if the next part is needed (if framerates are the same, audio should stay in sync)
-secs=$(ffprobe -i tmp.mp4 -show_entries format=duration -v quiet -of csv="p=0")
-ffmpeg -i music.wav -ss 0 -t $secs musicshort.wav
-ffmpeg -i musicshort.wav -i tmp.mp4 -strict -2 $1.mp4
-=======
 ${FFMPEG} -i "$2" /tmp/original.aac -y
 #${FFMPEG} -i /tmp/original.mp3 /tmp/music.wav
 
 #secs=$(${FFPROBE} -i /tmp/tmp.mp4 -show_entries format=duration -v quiet -of csv="p=0")
 #${FFMPEG} -i /tmp/music.wav -ss 0 -t ${secs} /tmp/musicshort.aac
 ${FFMPEG} -i /tmp/original.aac -i /tmp/tmp.mp4 -c:v copy -movflags faststart -shortest "${1}_done.mp4" -y
->>>>>>> 426b081b064d3748dae053f0efd1892fa7b7100c
+
+echo 'Removing temp files'
+rm /tmp/original.mp3
+echo "original.mp3 removed"
+rm /tmp/music.aac
+echo "music.wav removed"
+rm /tmp/musicshort.aac
+echo "musicshort.wav removed"
+#rm /tmp/tmp.mp4
+echo "tmp.mp4 removed"
 
 echo 'Removing temp files'
 rm /tmp/original.mp3

--- a/3_frames2movie.sh
+++ b/3_frames2movie.sh
@@ -1,15 +1,23 @@
 #!/bin/bash
 if [ $# -ne 2 ]; then
     echo "please provide the directory of the processed frames"
+    echo "usage:"
     echo "./3_frames2movie.sh [frames_directory] [original_video_with_sound]"
+    echo "\n example:"
+    echo "      ./3_frames2movie.sh /home/user/framesloath/ /home/user/fearloath.mp4"
     exit 1
 fi
 
-ffmpeg -framerate 25 -i $1/%4d.jpg -c:v libx264 -r 30 -pix_fmt yuv420p tmp.mp4
+# FFMPEG NEEDED -- TODO: Develop avconv alternative for this, or delete the avconv option in the first bash script.
+
+# Detect framerate of the original video
+frate=$(ffprobe -v error -select_streams v:0 -show_entries stream=avg_frame_rate -of default=noprint_wrappers=1:nokey=1 $2)
+ffmpeg -framerate $frate -i $1/%4d.jpg -c:v libx264 -r 30 -pix_fmt yuv420p tmp.mp4 # Use original framerate
 
 ffmpeg -i $2 original.mp3
 ffmpeg -i original.mp3 music.wav
 
+# Test if the next part is needed (if framerates are the same, audio should stay in sync)
 secs=$(ffprobe -i tmp.mp4 -show_entries format=duration -v quiet -of csv="p=0")
 ffmpeg -i music.wav -ss 0 -t $secs musicshort.wav
 ffmpeg -i musicshort.wav -i tmp.mp4 -strict -2 $1.mp4

--- a/3_frames2movie.sh
+++ b/3_frames2movie.sh
@@ -26,14 +26,3 @@ rm /tmp/musicshort.aac
 echo "musicshort.wav removed"
 #rm /tmp/tmp.mp4
 echo "tmp.mp4 removed"
-
-echo 'Removing temp files'
-rm /tmp/original.mp3
-echo "original.mp3 removed"
-rm /tmp/music.aac
-echo "music.wav removed"
-rm /tmp/musicshort.aac
-echo "musicshort.wav removed"
-#rm /tmp/tmp.mp4
-echo "tmp.mp4 removed"
-

--- a/3_frames2movie.sh
+++ b/3_frames2movie.sh
@@ -10,7 +10,7 @@ ffmpeg -framerate 25 -i $1/%4d.jpg -c:v libx264 -r 30 -pix_fmt yuv420p tmp.mp4
 ffmpeg -i $2 original.mp3
 ffmpeg -i original.mp3 music.wav
 
-secs=$(ffprobe -i $2.mp4 -show_entries format=duration -v quiet -of csv="p=0")
+secs=$(ffprobe -i $2 -show_entries format=duration -v quiet -of csv="p=0")
 ffmpeg -i music.wav -ss 0 -t $secs musicshort.wav
 ffmpeg -i musicshort.wav -i tmp.mp4 -strict -2 $1.mp4
 rm tmp.mp4

--- a/3_frames2movie.sh
+++ b/3_frames2movie.sh
@@ -36,3 +36,4 @@ rm /tmp/musicshort.aac
 echo "musicshort.wav removed"
 #rm /tmp/tmp.mp4
 echo "tmp.mp4 removed"
+


### PR DESCRIPTION
By default FFMPEG extracts the number of frames that the video has, the same way as Mplayer does.
Avconv should work the same way, but i need someone to test it first.