### PR TITLE
Allof for GPU outside of 0 index

### DIFF
--- a/2_dreaming_time.py
+++ b/2_dreaming_time.py
@@ -272,13 +272,13 @@ def main(input, output, disp, gpu, model_path, model_name, preview, octaves, oct
                            mean = np.float32([104.0, 116.0, 122.0]), # ImageNet mean, training set dependent
                            channel_swap = (2,1,0)) # the reference model has channels in BGR order instead of RGB
 
-    if gpu == '0':
+    if gpu is None:
+        print("SHITTTTTTTTTTTTTT You're running CPU man =D")
+    else:
         caffe.set_mode_gpu()
         caffe.set_device(int(args.gpu))
         print("GPU mode [device id: %s]" % args.gpu)
         print("using GPU, but you'd still better make a cup of coffee")
-    else:
-        print("SHITTTTTTTTTTTTTT You're running CPU man =D")
 
     if disp:
         from IPython.display import clear_output, Image, display


### PR DESCRIPTION
Noticed I couldn't utilize GPUs 2, 3, and 4 on g2.8xlarge EC2 instance. This PR resolved the issue for me.