### PR TITLE
Update 2_dreaming_time.py

### DIFF
--- a/2_dreaming_time.py
+++ b/2_dreaming_time.py
@@ -6,6 +6,7 @@ import os, os.path
 import errno
 import sys
 import time
+import subprocess
 from random import randint
 
 from cStringIO import StringIO
@@ -16,6 +17,9 @@ from google.protobuf import text_format
 
 import caffe
 
+def extractVideo(inputdir, outputdir):
+    print subprocess.Popen('ffmpeg -i ' + inputdir + ' -f image2 ' + outputdir + '/%08d.png', shell=True,
+                           stdout=subprocess.PIPE).stdout.read()
 
 def showarray(a, fmt='jpeg'):
     a = np.uint8(np.clip(a, 0, 255))
@@ -468,6 +472,11 @@ if __name__ == "__main__":
         type=int,
     	required=False,
     	help="end frame nr")
+    parser.add_argument(
+	'-e', '--extract',
+	type=int,
+	required=False,
+	help="Extract frames from video")
 
     args = parser.parse_args()
 
@@ -486,8 +495,12 @@ if __name__ == "__main__":
         print("Please set the model_name to a correct caffe model")
         print("or download one with ./caffe_dir/scripts/download_model_binary.py caffe_dir/models/bvlc_googlenet")
         sys.exit(0)
+        
+    if args.extract is 1:
+        extractVideo(args.input, args.output)
 
-    main(args.input, args.output, args.image_type, args.gpu, args.model_path, args.model_name, args.preview, args.octaves, args.octavescale, args.iterations, args.jitter, args.zoom, args.stepsize, args.blend, args.layers, args.guide_image, args.start_frame, args.end_frame, args.verbose)
+    else:
+    	main(args.input, args.output, args.image_type, args.gpu, args.model_path, args.model_name, args.preview, args.octaves, args.octavescale, args.iterations, args.jitter, args.zoom, args.stepsize, args.blend, args.layers, args.guide_image, args.start_frame, args.end_frame, args.verbose)
 
 
 


### PR DESCRIPTION
Hi @graphific. After doing some research, and getting all the dependencies for Caffe Python Cuda and Cudnn installed under windows natively (I've been interested in using my GPU, and docker doesn't pass through gpu computation) decided to start playing both with 2_deepdreamvideo and also deepdreamanim by @Samim23. 

Unfortunately there's a difference between the way both of your scripts handle unpacking of .mp4 files to image sequences. Through some trial but mostly error (having a very little bit of previous programming experience) I've cobbled together the -e argument from DeepDreamAnim into a fork of DeepDreamVideo.

I looked at the .sh files, but couldn't figure out what I would have to do to them to run them under the windows command line. 

Including a simple python -extract may not be as powerful as using the .sh bash scripts (it can only utilize FFMPEG at this juncture) but it elegantly opens up DeepDreamVideo to a new OS without reinventing the wheel. 

The credit for the original code should go to @Samim23. My involvement has been, simply, to copy paste appropriately and then test.

Warm regards