### PR TITLE
changed remaining time estimate to zero upon completion

### DIFF
--- a/2_dreaming_time.py
+++ b/2_dreaming_time.py
@@ -310,6 +310,7 @@ def main(input, output, image_type, gpu, model_path, model_name, preview, octave
         frame = np.float32(resizePicture(input + '/%08d.%s' % (frame_i, image_type), preview))
 
     now = time.time()
+    totaltime = 0
     
     if blend == 'loop':
         blend_forward = True
@@ -339,12 +340,14 @@ def main(input, output, image_type, gpu, model_path, model_name, preview, octave
 
         later = time.time()
         difference = int(later - now)
+        totaltime += difference
+        avgtime = (totaltime / i)
         # Stats (stolen + adapted from Samim: https://github.com/samim23/DeepDreamAnim/blob/master/dreamer.py)
         print '***************************************'
         print 'Saving Image As: ' + saveframe
         print 'Frame ' + str(i) + ' of ' + str(nrframes-1)
         print 'Frame Time: ' + str(difference) + 's'
-        timeleft = difference * (nrframes - frame_i)
+        timeleft = avgtime * ((nrframes-1) - frame_i)        
         m, s = divmod(timeleft, 60)
         h, m = divmod(m, 60)
         print 'Estimated Total Time Remaining: ' + str(timeleft) + 's (' + "%d:%02d:%02d" % (h, m, s) + ')'


### PR DESCRIPTION
I was using this to process a very small set of frames and noticed that the estimated total time remaining was noting one extra frame, so as it finished processing the last frame it still said that there was time remaining. Also, estimated time remaining was based on processing time for the last frame processed, not the average time of frames processed up to that point(kind of a stylistic choice but I think average makes more sense). Here is the comparison of output between the original code and after the change I made(chopped a little of the output for clarity):

Original:

Frame 1 of 5
Frame Time: 177s
Estimated Total Time Remaining: 885s (0:14:45)

Frame 2 of 5
Frame Time: 177s
Estimated Total Time Remaining: 708s (0:11:48)

Frame 3 of 5
Frame Time: 177s
Estimated Total Time Remaining: 531s (0:08:51)

Frame 4 of 5
Frame Time: 176s
Estimated Total Time Remaining: 352s (0:05:52)

Frame 5 of 5
Frame Time: 176s
Estimated Total Time Remaining: 176s (0:02:56)

Post fix:

Frame 1 of 5
Frame Time: 176s
Estimated Total Time Remaining: 704s (0:11:44)

Frame 2 of 5
Frame Time: 175s
Estimated Total Time Remaining: 525s (0:08:45)

Frame 3 of 5
Frame Time: 177s
Estimated Total Time Remaining: 352s (0:05:52)

Frame 4 of 5
Frame Time: 177s
Estimated Total Time Remaining: 176s (0:02:56)

Frame 5 of 5
Frame Time: 177s
Estimated Total Time Remaining: 0s (0:00:00)

P.S. Not a Python coder, so no concept of best practices...